### PR TITLE
🔀::/members 명령어에 출력되는 유저명 사이 공백 제거

### DIFF
--- a/src/commands/SearchMSGMemberCommand.ts
+++ b/src/commands/SearchMSGMemberCommand.ts
@@ -86,10 +86,11 @@ export default {
         filter: ({ user }) => user.id === interaction.user.id
       });
       let currentIndex = 0;
+      
       collector.on("collect", async (collectInteraction) => {
         collectInteraction.customId === prevID ? (currentIndex -= 10) : (currentIndex += 10);
         await collectInteraction.update({
-          content: `usernames: ${members.map((u) => `\`${u.user.username}\``).join(", ")}`,
+          content: `usernames: ${members.map((u) => `\`${u.user.username}\``).join(",")}`,
           embeds: [generateEmbed(currentIndex)],
           components: [
             new ActionRowBuilder<ButtonBuilder>({
@@ -101,6 +102,7 @@ export default {
           ]
         });
       });
+
     } catch (error) {
       await interaction.reply({
         content: `${error}`


### PR DESCRIPTION
## 💡 개요
usernames: nickname, nickname, nickname에서
usernames: nickname,nickname,nickname처럼 이름 사이 공백이 제거되었습니다.

## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
