### PR TITLE
🔀 :: Schedule 도메인 관련 데이터 작업 객체 추가

### DIFF
--- a/src/models/Schedule.ts
+++ b/src/models/Schedule.ts
@@ -1,0 +1,16 @@
+export interface Schedule {
+  id: string;
+  guildID: string;
+  channelID: string;
+  title: string;
+  content: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  userIDs: string[];
+  isOnReminder: boolean;
+  isRepeat: boolean;
+  repeatPattern: string;
+}

--- a/src/repositories/ScheduleRepository.ts
+++ b/src/repositories/ScheduleRepository.ts
@@ -1,0 +1,74 @@
+import { Schedule } from "../models/Schedule";
+import { collection, deleteDoc, doc, getDoc, getDocs, setDoc } from "firebase/firestore";
+import { firestore } from "../firebase";
+
+export interface ScheduleRepository {
+  getAllSchedules(): Promise<Schedule[]>;
+  getSchedules(filter: (schedule: Schedule) => boolean): Promise<Schedule[]>;
+  syncRemote(): Promise<void>;
+  saveSchedule(schedule: Schedule): Promise<void>;
+  deleteSchedule(scheduleID: string): Promise<void>;
+}
+
+class DefaultScheduleRepository implements ScheduleRepository {
+  cachedSchedule = new Map<string, Schedule>();
+  scheduleKey = "Schedule";
+
+  async getAllSchedules(): Promise<Schedule[]> {
+    let schedules: Schedule[] = [];
+    for (let [_, schedule] of this.cachedSchedule.entries()) {
+      schedules.push(schedule);
+    }
+    return schedules;
+  }
+
+  async getSchedules(filter: (schedule: Schedule) => boolean): Promise<Schedule[]> {
+    let schedules: Schedule[] = [];
+    for (let [_, schedule] of this.cachedSchedule.entries()) {
+      if (filter(schedule)) {
+        schedules.push(schedule);
+      }
+    }
+    return schedules;
+  }
+
+  async syncRemote(): Promise<void> {
+    const snapshot = await getDocs(collection(firestore, this.scheduleKey));
+    snapshot.docs.forEach((doc) => {
+      const data = doc.data();
+      const schedule = {
+        id: doc.id,
+        guildID: data.guildID,
+        channelID: data.channelID,
+        title: data.title,
+        content: data.content,
+        year: data.year,
+        month: data.month,
+        day: data.day,
+        hour: data.hour,
+        minute: data.minute,
+        userIDs: data.userIDs,
+        isOnReminder: data.isOnReminder,
+        isRepeat: data.isRepeat,
+        repeatPattern: data.repeatPattern
+      };
+      this.cachedSchedule.clear();
+      this.cachedSchedule.set(doc.id, schedule);
+    });
+  }
+
+  async saveSchedule(schedule: Schedule): Promise<void> {
+    await setDoc(doc(firestore, this.scheduleKey, schedule.id), {
+      ...schedule
+    });
+    this.cachedSchedule.set(schedule.id, schedule);
+    return;
+  }
+
+  async deleteSchedule(scheduleID: string): Promise<void> {
+    await deleteDoc(doc(firestore, this.scheduleKey, scheduleID));
+    this.cachedSchedule.delete(scheduleID);
+  }
+}
+
+export const scheduleRepository: ScheduleRepository = new DefaultScheduleRepository();


### PR DESCRIPTION
## 💡 개요
Schedule 도메인에 대해서 프로젝트에 추가

## 📃 작업내용
- Schedule 엔티티 추가
  - 일정 이름
  - 일정 설명
  - 일정 날짜
  - 일정 알림 채널
  - 일정 반복 활성화 여부
  - 일정 반복 패턴
  - 일정 리마인더 활성화 여부
  - 일정 대상 유저들의 ID
- Schedule 데이터를 다루는 Repository 추가

