### PR TITLE
🔀 :: Schedule 도메인 관련 Command와 Job 봇에 등록

### DIFF
--- a/src/MSGSaltBot.ts
+++ b/src/MSGSaltBot.ts
@@ -11,6 +11,10 @@ import { Command } from "./interfaces/Command";
 import { saltRepository } from "./repositories/SaltRepository";
 import { config } from "./utils/config";
 import { JobService } from "./services/JobService";
+import AddScheduleCommand from "./commands/AddScheduleCommand";
+import SyncScheduleCommand from "./commands/SyncScheduleCommand";
+import FetchScheduleListCommand from "./commands/FetchScheduleListCommand";
+import DeleteScheduleCommand from "./commands/DeleteScheduleCommand";
 
 export class MSGSaltBot {
   private slashCommandMap = new Map<string, Command>();
@@ -45,7 +49,11 @@ export class MSGSaltBot {
       DMCommand,
       SearchMSGMemberCommand,
       CurrentSaltCommand,
-      FilterMensionCommand
+      FilterMensionCommand,
+      AddScheduleCommand,
+      SyncScheduleCommand,
+      FetchScheduleListCommand,
+      DeleteScheduleCommand
     ];
 
     this.slashCommandMap = slashCommands.reduce((map, command) => {
@@ -75,9 +83,15 @@ export class MSGSaltBot {
       } catch (error: any) {
         console.error(error);
 
-        await interaction.reply({
-          content: error.toString()
-        });
+        if (interaction.replied) {
+          await interaction.followUp({
+            content: error.toString()
+          });
+        } else {
+          await interaction.reply({
+            content: error.toString()
+          });
+        }
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,15 @@ import express, { Express } from "express";
 import { client } from "./discordClient";
 import { JobService } from "./services/JobService";
 import { Job } from "./interfaces/Job";
+import { ReminderSchedulerJob } from "./jobs/ReminderSchedulerJob";
+import { scheduleRepository } from "./repositories/ScheduleRepository";
+import { SchedulerJob } from "./jobs/SchedulerJob";
 
+scheduleRepository.syncRemote()
 
 const jobs: Job[] = [
+  new ReminderSchedulerJob(client),
+  new SchedulerJob(client)
 ];
 
 const jobService = new JobService(jobs);


### PR DESCRIPTION
## 💡 개요
Schedule 도메인 관련 추가된 Command와 Job을 봇에 등록

## 📃 작업내용
- Schedule 추가 Command 등록
- Schedule 리스트 가져오는 Command 등록
- Schedule 삭제 Command 등록
- Schedule 캐시를 원격과 동기화하는 Command 등록
- 일정 시작 전 15분전에 리마인더를 보내주는 Job 등록
- 일정 시작시 알림을 보내주는 Job 등록
- 매일 아침 8시에 오늘 잡힌 일정을 보내주는 Job 등록
- mention용 FormatUtils 추가
  - user mention 메서드 추가
  - channel mention 메서드 추가

