### PR TITLE
🔀 :: [#30] 스케쥴 동기화 실행 시, 하나의 일정만 설정됨

### DIFF
--- a/src/repositories/ScheduleRepository.ts
+++ b/src/repositories/ScheduleRepository.ts
@@ -34,6 +34,7 @@ class DefaultScheduleRepository implements ScheduleRepository {
 
   async syncRemote(): Promise<void> {
     const snapshot = await getDocs(collection(firestore, this.scheduleKey));
+    this.cachedSchedule.clear();
     snapshot.docs.forEach((doc) => {
       const data = doc.data();
       const schedule = {
@@ -52,7 +53,6 @@ class DefaultScheduleRepository implements ScheduleRepository {
         isRepeat: data.isRepeat,
         repeatPattern: data.repeatPattern
       };
-      this.cachedSchedule.clear();
       this.cachedSchedule.set(doc.id, schedule);
     });
   }


### PR DESCRIPTION
## 💡 개요
스케쥴 동기화 시, 하나의 일정만 설정됨

## 📃 작업내용
- 스케쥴 동기화할 때 모든 일정을 캐시에 반영하도록 변경

## 🔀 변경사항
모든 일정으로 for를 돌려서 Map에 저장하는데 for cycle마다 Map을 clear에서 단 하나의 일정만 저장됨
-> 최초 한번만 clear를 하도록 변경

